### PR TITLE
Fix accept call functionality

### DIFF
--- a/walker-backend/src/controllers/call.ts
+++ b/walker-backend/src/controllers/call.ts
@@ -28,17 +28,27 @@ class CallController {
   public acceptCall = async (req: Request, res: Response) => {
     const body = req.body
     const currAccepter = await User.findById(body.accepter)
-    const currCall = await Call.findById(body.call)
-    const update = { accepter: currAccepter, status: true}
-    if (currCall) {
-      currCall.updateOne(update)
-        .then((currCall: ICall | null) => {
-          return res.status(200).json(currCall)
-        })
-    }
-    else {
-      return res.status(500).json(`Cannot find call with ID ${body.call}`)
-    }
+    const update = { accepter: currAccepter, status: true }
+    Call.findByIdAndUpdate(body.call, update).then((currCall: ICall | null) => {
+      console.log(currCall)
+      CoOp.findOneAndUpdate(
+        {
+          'calls._id': body.call,
+        },
+        {
+          $set: {
+            'calls.$.status': true,
+            'calls.$.accepter': currAccepter,
+          },
+        }, {
+        new: true,
+      }).then((data) => {
+        console.log(data);
+        return res.status(200).json(data)
+      })
+    }).catch((err: Error) => {
+      return res.status(500).json(err)
+    });
   }
 
   public getAllCalls = async (req: Request, res: Response) => {

--- a/walker/.env
+++ b/walker/.env
@@ -1,0 +1,2 @@
+REACT_APP_BACKEND_URL_PROD=https://walker-backend.fly.dev/api
+REACT_APP_BACKEND_URL_DEV="http://localhost:8000/api"

--- a/walker/package-lock.json
+++ b/walker/package-lock.json
@@ -8,10 +8,13 @@
             "name": "walker",
             "version": "0.1.0",
             "dependencies": {
+                "@emotion/react": "^11.10.8",
+                "@emotion/styled": "^11.10.8",
                 "@fullcalendar/core": "^6.1.5",
                 "@fullcalendar/daygrid": "^6.1.5",
                 "@fullcalendar/interaction": "^6.1.5",
                 "@fullcalendar/react": "^6.1.5",
+                "@mui/material": "^5.12.2",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^13.4.0",
                 "@testing-library/user-event": "^13.5.0",
@@ -2140,6 +2143,158 @@
                 "postcss-selector-parser": "^6.0.10"
             }
         },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.10.8",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.8.tgz",
+            "integrity": "sha512-gxNky50AJL3AlkbjvTARiwAqei6/tNUxDZPSKd+3jqWVM3AmdVTTdpjHorR/an/M0VJqdsuq5oGcFH+rjtyujQ==",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.0",
+                "@emotion/memoize": "^0.8.0",
+                "@emotion/serialize": "^1.1.1",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.1.4"
+            }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@emotion/cache": {
+            "version": "11.10.8",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.8.tgz",
+            "integrity": "sha512-5fyqGHi51LU95o7qQ/vD1jyvC4uCY5GcBT+UgP4LHdpO9jPDlXqhrRr9/wCKmfoAvh5G/F7aOh4MwQa+8uEqhA==",
+            "dependencies": {
+                "@emotion/memoize": "^0.8.0",
+                "@emotion/sheet": "^1.2.1",
+                "@emotion/utils": "^1.2.0",
+                "@emotion/weak-memoize": "^0.3.0",
+                "stylis": "4.1.4"
+            }
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+            "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+        },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+            "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+            "dependencies": {
+                "@emotion/memoize": "^0.8.0"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+            "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+        },
+        "node_modules/@emotion/react": {
+            "version": "11.10.8",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.8.tgz",
+            "integrity": "sha512-ZfGfiABtJ1P1OXqOBsW08EgCDp5fK6C5I8hUJauc/VcJBGSzqAirMnFslhFWnZJ/w5HxPI36XbvMV0l4KZHl+w==",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.10.8",
+                "@emotion/cache": "^11.10.8",
+                "@emotion/serialize": "^1.1.1",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+                "@emotion/utils": "^1.2.0",
+                "@emotion/weak-memoize": "^0.3.0",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+            "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+            "dependencies": {
+                "@emotion/hash": "^0.9.0",
+                "@emotion/memoize": "^0.8.0",
+                "@emotion/unitless": "^0.8.0",
+                "@emotion/utils": "^1.2.0",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/sheet": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+            "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+        },
+        "node_modules/@emotion/styled": {
+            "version": "11.10.8",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.8.tgz",
+            "integrity": "sha512-gow0lF4Uw/QEdX2REMhI8v6wLOabPKJ+4HKNF0xdJ2DJdznN6fxaXpQOx6sNkyBhSUL558Rmcu1Lq/MYlVo4vw==",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.10.8",
+                "@emotion/is-prop-valid": "^1.2.0",
+                "@emotion/serialize": "^1.1.1",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+                "@emotion/utils": "^1.2.0"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.0.0-rc.0",
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+            "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+        },
+        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@emotion/utils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+            "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+        },
+        "node_modules/@emotion/weak-memoize": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+            "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
+        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -3021,6 +3176,237 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
             "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+        },
+        "node_modules/@mui/base": {
+            "version": "5.0.0-alpha.127",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.127.tgz",
+            "integrity": "sha512-FoRQd0IOH9MnfyL5yXssyQRnC4vXI+1bwkU1idr+wNkP1ZfxE+JsThHcfl1dy5azLssVUGTtQFD9edQLdbyJog==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0",
+                "@emotion/is-prop-valid": "^1.2.0",
+                "@mui/types": "^7.2.4",
+                "@mui/utils": "^5.12.0",
+                "@popperjs/core": "^2.11.7",
+                "clsx": "^1.2.1",
+                "prop-types": "^15.8.1",
+                "react-is": "^18.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/base/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        },
+        "node_modules/@mui/core-downloads-tracker": {
+            "version": "5.12.2",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.12.2.tgz",
+            "integrity": "sha512-Qn7dy8tql6T0hY6gTFPkpWlnqVVFGu5Z6QzEzUSzzmLZpfAx4kf8sFz0PHiB7gU5yrqcZF9picMx1shpRY/rXw==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            }
+        },
+        "node_modules/@mui/material": {
+            "version": "5.12.2",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.12.2.tgz",
+            "integrity": "sha512-XOVy6fVC0rI2dEwDq/1s4Te2hewTUe6lznzeVnruyATGkdmM06WnHqkZOoLVIWo9hWwAxpcgTDcAIVpFtt1nrw==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0",
+                "@mui/base": "5.0.0-alpha.127",
+                "@mui/core-downloads-tracker": "^5.12.2",
+                "@mui/system": "^5.12.1",
+                "@mui/types": "^7.2.4",
+                "@mui/utils": "^5.12.0",
+                "@types/react-transition-group": "^4.4.5",
+                "clsx": "^1.2.1",
+                "csstype": "^3.1.2",
+                "prop-types": "^15.8.1",
+                "react-is": "^18.2.0",
+                "react-transition-group": "^4.4.5"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/material/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        },
+        "node_modules/@mui/private-theming": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.12.0.tgz",
+            "integrity": "sha512-w5dwMen1CUm1puAtubqxY9BIzrBxbOThsg2iWMvRJmWyJAPdf3Z583fPXpqeA2lhTW79uH2jajk5Ka4FuGlTPg==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0",
+                "@mui/utils": "^5.12.0",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/styled-engine": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.12.0.tgz",
+            "integrity": "sha512-frh8L7CRnvD0RDmIqEv6jFeKQUIXqW90BaZ6OrxJ2j4kIsiVLu29Gss4SbBvvrWwwatR72sBmC3w1aG4fjp9mQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0",
+                "@emotion/cache": "^11.10.7",
+                "csstype": "^3.1.2",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/system": {
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.12.1.tgz",
+            "integrity": "sha512-Po+sicdV3bbRYXdU29XZaHPZrW7HUYUqU1qCu77GCCEMbahC756YpeyefdIYuPMUg0OdO3gKIUfDISBrkjJL+w==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0",
+                "@mui/private-theming": "^5.12.0",
+                "@mui/styled-engine": "^5.12.0",
+                "@mui/types": "^7.2.4",
+                "@mui/utils": "^5.12.0",
+                "clsx": "^1.2.1",
+                "csstype": "^3.1.2",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/types": {
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
+            "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+            "peerDependencies": {
+                "@types/react": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/utils": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.12.0.tgz",
+            "integrity": "sha512-RmQwgzF72p7Yr4+AAUO6j1v2uzt6wr7SWXn68KBsnfVpdOHyclCzH2lr/Xu6YOw9su4JRtdAIYfJFXsS6Cjkmw==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0",
+                "@types/prop-types": "^15.7.5",
+                "@types/react-is": "^16.7.1 || ^17.0.0",
+                "prop-types": "^15.8.1",
+                "react-is": "^18.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@mui/utils/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
@@ -4043,6 +4429,32 @@
             "version": "18.0.11",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
             "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@types/react-is": {
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.4.tgz",
+            "integrity": "sha512-FLzd0K9pnaEvKz4D1vYxK9JmgQPiGk1lu23o1kqGsLeT0iPbRSF7b76+S5T9fD8aRa0B8bY7I/3DebEj+1ysBA==",
+            "dependencies": {
+                "@types/react": "^17"
+            }
+        },
+        "node_modules/@types/react-is/node_modules/@types/react": {
+            "version": "17.0.58",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
+            "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/react-transition-group": {
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
             "dependencies": {
                 "@types/react": "*"
             }
@@ -8027,6 +8439,11 @@
                 "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
             }
         },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -8759,6 +9176,19 @@
             "bin": {
                 "he": "bin/he"
             }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/hoist-non-react-statics/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/hoopy": {
             "version": "0.1.4",
@@ -14711,6 +15141,21 @@
                 }
             }
         },
+        "node_modules/react-transition-group": {
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.6.0",
+                "react-dom": ">=16.6.0"
+            }
+        },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15845,6 +16290,11 @@
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
+        },
+        "node_modules/stylis": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.4.tgz",
+            "integrity": "sha512-USf5pszRYwuE6hg9by0OkKChkQYEXfkeTtm0xKw+jqQhwyjCVLdYyMBK7R+n7dhzsblAWJnGxju4vxq5eH20GQ=="
         },
         "node_modules/sucrase": {
             "version": "3.32.0",

--- a/walker/package.json
+++ b/walker/package.json
@@ -5,10 +5,13 @@
     "homepage": ".",
     "proxy": "http://localhost:8000",
     "dependencies": {
+        "@emotion/react": "^11.10.8",
+        "@emotion/styled": "^11.10.8",
         "@fullcalendar/core": "^6.1.5",
         "@fullcalendar/daygrid": "^6.1.5",
         "@fullcalendar/interaction": "^6.1.5",
         "@fullcalendar/react": "^6.1.5",
+        "@mui/material": "^5.12.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/walker/src/pages/CoOpHome.tsx
+++ b/walker/src/pages/CoOpHome.tsx
@@ -276,6 +276,10 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
                         id="modal-modal-title"
                         variant="h6"
                         component="h2"
+                        style={{
+                            fontWeight: 600,
+                            color: openCall?.status ? "green" : "red",
+                        }}
                     >
                         {openCall?.requester?.pet_name} - {openCall?.activity}
                     </Typography>

--- a/walker/src/pages/CoOpHome.tsx
+++ b/walker/src/pages/CoOpHome.tsx
@@ -3,6 +3,9 @@ import { useParams } from "react-router-dom";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import { Link } from "react-router-dom";
+import Modal from "@mui/material/Modal";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 
 import styles from "./CoOp.module.css";
 import logo from "../assets/logo.png";
@@ -31,6 +34,7 @@ interface GroupMember {
 
 interface ExtendedProps {
     accepted: boolean;
+    setOpen: () => void;
 }
 
 interface EventInfo {
@@ -42,20 +46,37 @@ interface EventInfo {
     };
 }
 
-const getCalObj = ({ activity, date, details, requester, status }: ICall) => {
-    return {
-        title: `${requester?.pet_name} - ${activity}`,
-        start: date,
-        extendedProps: {
-            accepted: status ?? false,
-            details,
-        },
-    };
+const style = {
+    position: "absolute" as "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: 400,
+    bgcolor: "background.paper",
+    borderRadius: "10px",
+    boxShadow: 24,
+    p: 4,
 };
 
 function CoOpHome({ user }: { user: any }): JSX.Element {
     const [coop, setCoop] = useState();
     const [calls, setCalls] = useState([]);
+
+    const [openCall, setOpenCall] = useState(null);
+    const handleClose = () => setOpenCall(null);
+
+    const getCalObj = (call: ICall) => {
+        return {
+            title: `${call.requester?.pet_name} - ${call.activity}`,
+            start: call.date,
+            extendedProps: {
+                accepted: call.status ?? false,
+                details: call.details,
+                setOpen: () => setOpenCall(call),
+            },
+        };
+    };
+
     const { id } = useParams();
 
     const handleAcceptCall = async (call: any) => {
@@ -244,6 +265,32 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
                     </div>
                 </div>
             </div>
+            <Modal
+                open={openCall}
+                onClose={handleClose}
+                aria-labelledby="modal-modal-title"
+                aria-describedby="modal-modal-description"
+            >
+                <Box sx={style}>
+                    <Typography
+                        id="modal-modal-title"
+                        variant="h6"
+                        component="h2"
+                    >
+                        {openCall?.requester?.pet_name} - {openCall?.activity}
+                    </Typography>
+                    <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+                        <p>Date: {openCall?.date}</p>
+                        <p>Details: {openCall?.details}</p>
+                        {openCall?.status && (
+                            <p>
+                                Walker Call Accepter:{" "}
+                                {openCall?.accepter?.person_name}
+                            </p>
+                        )}
+                    </Typography>
+                </Box>
+            </Modal>
         </div>
     );
 }
@@ -259,6 +306,7 @@ function renderEventContent(eventInfo: EventInfo) {
                 }`,
             }}
             className={styles.event}
+            onClick={eventInfo.event.extendedProps.setOpen}
         >
             {eventInfo.timeText} <b>{eventInfo.event.title}</b>
         </p>

--- a/walker/src/pages/CoOpHome.tsx
+++ b/walker/src/pages/CoOpHome.tsx
@@ -57,7 +57,6 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
     const [coop, setCoop] = useState();
     const [calls, setCalls] = useState([]);
     const { id } = useParams();
-    const [acceptedCalls, setAcceptedCalls] = useState(new Set());
 
     const handleAcceptCall = async (call: any) => {
         try {
@@ -67,12 +66,14 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    "accepter": user._id,
-                    "call": call._id
+                    accepter: user._id,
+                    call: call._id,
                 }),
             });
-            setAcceptedCalls(new Set([...acceptedCalls, call._id]));
-            console.log(response);
+            const data = await response.json();
+            setCoop(data);
+            setCalls(data?.calls ?? []);
+            console.log("res", data);
         } catch (error) {
             console.error("Error accepting walker call", error);
         }
@@ -120,34 +121,66 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
                         Pending Walker Calls
                     </p>
                     <ul>
-
-<div style={{ display: "flex", flexDirection: "column" }}>
-  <div style={{ display: "flex", flexDirection: "row", fontWeight: "bold" }}>
-    <div style={{ flex: 1 }}>Pet Name</div>
-    <div style={{ flex: 1 }}>Activity</div>
-    <div style={{ flex: 1 }}>Time</div>
-    <div style={{ flex: 2 }}>Details</div>
-    <div style={{ flex: 1 }}>Status</div>
-  </div>
-  {calls.map((call: any, index: number) => (
-    <div key={index} style={{ display: "flex", flexDirection: "row", marginBottom: "5px" }}>
-      <div style={{ flex: 1 }}>{call.requester?.pet_name}</div>
-      <div style={{ flex: 1 }}>{call.activity}</div>
-      <div style={{ flex: 1 }}>{new Date(call.date).toLocaleString()}</div>
-      <div style={{ flex: 2 }}>{call.details}</div>
-      <div style={{ flex: 1 }}>
-        {(acceptedCalls.has(call._id))? (
-          <div style={{ display: "inline-block" }}>Call accepted!</div>
-        ) : (
-          <button className="btn" onClick={() => handleAcceptCall(call)}>
-            Accept Call
-          </button>
-        )}
-      </div>
-    </div>
-  ))}
-</div>
-
+                        <div
+                            style={{ display: "flex", flexDirection: "column" }}
+                        >
+                            <div
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "row",
+                                    fontWeight: "bold",
+                                }}
+                            >
+                                <div style={{ flex: 1 }}>Pet Name</div>
+                                <div style={{ flex: 1 }}>Activity</div>
+                                <div style={{ flex: 1 }}>Time</div>
+                                <div style={{ flex: 2 }}>Details</div>
+                                <div style={{ flex: 1 }}>Status</div>
+                            </div>
+                            {calls.map((call: any, index: number) => (
+                                <div
+                                    key={index}
+                                    style={{
+                                        display: "flex",
+                                        flexDirection: "row",
+                                        marginBottom: "5px",
+                                    }}
+                                >
+                                    <div style={{ flex: 1 }}>
+                                        {call.requester?.pet_name}
+                                    </div>
+                                    <div style={{ flex: 1 }}>
+                                        {call.activity}
+                                    </div>
+                                    <div style={{ flex: 1 }}>
+                                        {new Date(call.date).toLocaleString()}
+                                    </div>
+                                    <div style={{ flex: 2 }}>
+                                        {call.details}
+                                    </div>
+                                    <div style={{ flex: 1 }}>
+                                        {call.status ? (
+                                            <div
+                                                style={{
+                                                    display: "inline-block",
+                                                }}
+                                            >
+                                                Call accepted!
+                                            </div>
+                                        ) : (
+                                            <button
+                                                className="btn"
+                                                onClick={() =>
+                                                    handleAcceptCall(call)
+                                                }
+                                            >
+                                                Accept Call
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
                     </ul>
                     <p className={"subheading"} style={{ fontSize: "36px" }}>
                         Co-Op Calendar

--- a/walker/src/pages/CoOpHome.tsx
+++ b/walker/src/pages/CoOpHome.tsx
@@ -73,7 +73,6 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
             const data = await response.json();
             setCoop(data);
             setCalls(data?.calls ?? []);
-            console.log("res", data);
         } catch (error) {
             console.error("Error accepting walker call", error);
         }
@@ -165,7 +164,8 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
                                                     display: "inline-block",
                                                 }}
                                             >
-                                                Call accepted!
+                                                Call accepted by{" "}
+                                                {call.accepter?.person_name}
                                             </div>
                                         ) : (
                                             <button

--- a/walker/src/pages/CoOpHome.tsx
+++ b/walker/src/pages/CoOpHome.tsx
@@ -284,7 +284,8 @@ function CoOpHome({ user }: { user: any }): JSX.Element {
                         {openCall?.requester?.pet_name} - {openCall?.activity}
                     </Typography>
                     <Typography id="modal-modal-description" sx={{ mt: 2 }}>
-                        <p>Date: {openCall?.date}</p>
+                        <p>Date: {new Date(openCall?.date).toLocaleString()}</p>
+                        <p>Requester: {openCall?.requester?.person_name}</p>
                         <p>Details: {openCall?.details}</p>
                         {openCall?.status && (
                             <p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In accept-calls-integration, call accepted state is not persisted after page refresh due to state being reset. This PR persists the change in the embedded documents of the `calls` list, while still dynamically updating the frontend. 

Also adds modals when calendar events are clicked:
![image](https://user-images.githubusercontent.com/50491000/235692725-fa6dc564-04a6-4e7b-8c54-6d175542e7c7.png)
Resolves #33 

## How Has This Been Tested?
* Log into co-op
* Create walker call
* Check that status changes from "Accept Call" button to "Call accepted!" text
* Check that calendar call entry changes from red to green

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
